### PR TITLE
ios13の対応

### DIFF
--- a/src/ios/Diagnostic_Bluetooth.m
+++ b/src/ios/Diagnostic_Bluetooth.m
@@ -90,7 +90,7 @@ static NSString*const LOG_TAG = @"Diagnostic_Bluetooth[native]";
 {
     [self.commandDelegate runInBackground:^{
         @try {
-            [self ensureBluetoothManager];
+            // [self ensureBluetoothManager]; // ios13のためにコメントアウト
             [diagnostic sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK] :command];
         }
         @catch (NSException *exception) {


### PR DESCRIPTION
今までpluginInitializeの中で動いていた
```
         self.bluetoothManager = [[CBCentralManager alloc]
                                 initWithDelegate:self
                                 queue:dispatch_get_main_queue()
                                 options:@{CBCentralManagerOptionShowPowerAlertKey: @(NO)}];
        [self centralManagerDidUpdateState:self.bluetoothManager]; // Send initial state
```

の箇所を、initializeから別メソッドに移す修正が
https://github.com/dpa99c/cordova-diagnostic-plugin/commit/aebedff8ddfa639d33ba5c8a5b15e12741950504#diff-642d11188eda393fd48b4d733d5d71a5 でありました。

しかしアプリ起動時にもensureBluetoothManagerが呼ばれてしまうことがあったので、一部コメントアウトすることで暫定対応中です。