### PR TITLE
Revert "ios13の対応"

### DIFF
--- a/src/ios/Diagnostic_Bluetooth.m
+++ b/src/ios/Diagnostic_Bluetooth.m
@@ -90,7 +90,7 @@ static NSString*const LOG_TAG = @"Diagnostic_Bluetooth[native]";
 {
     [self.commandDelegate runInBackground:^{
         @try {
-            // [self ensureBluetoothManager]; // ios13のためにコメントアウト
+            [self ensureBluetoothManager];
             [diagnostic sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK] :command];
         }
         @catch (NSException *exception) {


### PR DESCRIPTION
Reverts growthcone/cordova-diagnostic-plugin#3
コメントアウトした箇所は特に関係なかったので元に戻します。